### PR TITLE
Immediate state transitions in POE::NFA

### DIFF
--- a/lib/POE/NFA.pm
+++ b/lib/POE/NFA.pm
@@ -969,6 +969,11 @@ The C<runstate> parameter allows C<RUNSTATE> to be initialized differently
 at instantiation time. C<RUNSTATE>, like heaps, are usually anonymous hashrefs,
 but C<runstate> may set them to be array references or even objects.
 
+State transitions are not necessarily executed immediately by default.  Rather,
+they are placed in POEs event queue behind any currently pending events.
+Enabling the C<immediate> option causes state transitions to occur immediately,
+regardless of any queued events.
+
 =head2 goto_state NEW_STATE[, ENTRY_EVENT[, EVENT_ARGS]]
 
 goto_state() puts the machine into a new state.  If an ENTRY_EVENT is
@@ -984,11 +989,6 @@ event's handler via C<ARG0..$#_>.
 
   # Switch to the next state; call an entry point with some values.
   $_[MACHINE]->goto_state( 'next_state', 'entry_event', @parameters );
-
-State transitions are not necessarily executed immediately by default.  Rather,
-they are placed in POEs event queue behind any currently pending events.
-Enabling the C<immediate> option causes state transitions to occur immediately,
-regardless of any queued events.
 
 =head2 stop
 


### PR DESCRIPTION
I've run into a situation where POE::NFAs posting of state transitions into POEs event queue has become an issue.  My machine processes a string of events and the output of the machine is completely dependant upon the type and order of previous events.  As such, when an event causes a state change, I expect the change to happen immediately, because of and regardless of any not-yet-dispatched events in the event queue.

The crux of my issue is that due to NFAs non-immediate state transitions, the output of the machine is vastly different depending on whether or not the event queue contains any events at any point during its operation.  While there are certainly ways to mitigate or eliminate the queuing of the next event to be processed until after the state change has been posted, this is not desirable nor always possible.

In my readings, I stumbled across a thread [ http://code.activestate.com/lists/perl-poe/29/ ] from over a decade[!] ago regarding this same issue.  From my understanding, the core issue has not been completely resolved.  I have implemented an 'immediate' option for POE::NFA that, when enabled, causes state changes to be sent with 'call' rather than with 'post', which resolves the aforementioned issue.  I am hardly partial to my commits, but I would certainly appreciate further discussion on this topic.

Thanks!
David Huebner
