### PR TITLE
Fix POE::Wheel::Run not triggering StdinEvent

### DIFF
--- a/lib/POE/Wheel/Run.pm
+++ b/lib/POE/Wheel/Run.pm
@@ -677,7 +677,7 @@ sub _define_stdin_flusher {
       else {
 
         # All chunks written; fire off a "flushed" event.
-        unless ($$stdin_octets) {
+        if (!$$stdin_octets) {
           $k->select_pause_write($handle);
           $$stdin_event && $k->call($me, $$stdin_event, $unique_id);
         }


### PR DESCRIPTION
Driver/SysRw.pm contains a return of TOTAL_OCTETS_LEFT:

> sub flush {
> . . .
>   $self->[TOTAL_OCTETS_LEFT];
> }

This is the number of octets still pending to be sent.

But... Wheel/Run.pm contains the definer for the flusher..

> sub _define_stdin_flusher {
> . . .
>                               $$stdin_octets = $driver->flush($handle);
> . . .
>        # All chunks written; fire off a "flushed" event.
>        unless ($$stdin_octets) {
>          $k->select_pause_write($handle);
>          $$stdin_event && $k->call($me, $$stdin_event, $unique_id);
> . . .

It appears that $$stdin_octets is being used incorrectly in this context
as the StdinEvent would be triggered if there still is data pending to be
flushed.

The attached fix changes this to "if (!$$stdin_octets) {" which evaluates
to true when there is no data left to be flushed.
