### PR TITLE
Hard coded Unix-style directory separator causes problems on Windows with nmake

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -184,7 +184,7 @@ sub MY::postamble {
   return <<EOF;
 
 coverage: Makefile
-\cI$^X mylib/coverage.perl
+\cI$^X "mylib/coverage.perl"
 
 cover: coverage
 EOF
@@ -213,7 +213,7 @@ WriteMakefile(
   test           => { TESTS => TEST_FILES  },
 
   # Not executed on "make test".
-  PL_FILES       => { 'mylib/gen-tests.perl' => [ 'lib/POE.pm' ] },
+  PL_FILES       => { '"mylib/gen-tests.perl"' => [ 'lib/POE.pm' ] },
 
   PREREQ_PM      => { CORE_REQUIREMENTS },
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,6 +32,7 @@
 use strict;
 use ExtUtils::MakeMaker;
 use Config;
+use File::Spec;
 
 # Switch to default behavior if STDIN isn't a tty.
 
@@ -181,10 +182,11 @@ check_for_modules(
 ### Generate Makefile.PL.
 
 sub MY::postamble {
+  my $cov = File::Spec->catfile(mylib => 'coverage.perl');
   return <<EOF;
 
 coverage: Makefile
-\cI$^X "mylib/coverage.perl"
+\cI$^X $cov
 
 cover: coverage
 EOF
@@ -213,7 +215,7 @@ WriteMakefile(
   test           => { TESTS => TEST_FILES  },
 
   # Not executed on "make test".
-  PL_FILES       => { '"mylib/gen-tests.perl"' => [ 'lib/POE.pm' ] },
+  PL_FILES       => { File::Spec->catfile(mylib => 'gen-tests.perl') => [ 'lib/POE.pm' ] },
 
   PREREQ_PM      => { CORE_REQUIREMENTS },
 


### PR DESCRIPTION
Symptom:

<pre>        "C:\opt\perl-5.20.1\bin\perl.exe" mylib/gen-tests.perl lib/POE.pm
Can't open perl script "mylib": Permission denied
NMAKE : fatal error U1077: 'C:\opt\perl-5.20.1\bin\perl.exe' : return code '0xd'
Stop.</pre>

because perl ends up seeing `mylib` and `/gen-tests.perl` as two separate thingies.

Fix by using `File::Spec->catfile` to compose filenames.
