### PR TITLE
Skip tests that hang on MSWin32

### DIFF
--- a/lib/POE/Loop/Select.pm
+++ b/lib/POE/Loop/Select.pm
@@ -13,7 +13,12 @@ $VERSION = '1.367'; # NOTE - Should be #.### (three decimal places)
 
 =for poe_tests
 
-sub skip_tests { return }
+sub skip_tests {
+  my($test_name) = @_;
+  return "$test_name tests hang on $^O" if (
+    $test_name eq 'wheel_tail' && $^O eq "MSWin32"
+  );
+}
 
 =cut
 

--- a/t/10_units/04_drivers/01_sysrw.t
+++ b/t/10_units/04_drivers/01_sysrw.t
@@ -98,6 +98,11 @@ ok( $d->get_out_messages_buffered() == 1, "one message buffered" );
 
 # Remaining tests require some live handles.
 
+SKIP: { 
+if ($^O eq "MSWin32") {
+  skip "remaining tests hang on $^O", 6;
+}
+  
 my ($r, $w) = POE::Pipe::OneWay->new();
 die "can't open a pipe: $!" unless $r;
 
@@ -164,6 +169,8 @@ while (flush_remaining_buffer($d, $w)) {
   open(STDERR, ">&SAVE_STDERR") or die $!;
   close(SAVE_STDERR) or die $!;
 }
+
+} # SKIP
 
 exit 0;
 


### PR DESCRIPTION
01_sysrw.t hangs on MSWin32 when tested with live handles - these tests skipped.
wheel_tail.pm test hangs on MSWin32 - this test skipped.

Change tested on Perl v5.22.1 built for MSWin32-x86-multi-thread-64int