### PR TITLE
Update broken Pod links in lib/POE/Filter/HTTPD.pm

### DIFF
--- a/lib/POE/Filter/HTTPD.pm
+++ b/lib/POE/Filter/HTTPD.pm
@@ -621,10 +621,10 @@ how to use these objects.
 
 HTTP headers are not allowed to have UTF-8 characters; they must be
 ISO-8859-1.  POE::Filter::HTTPD will convert all UTF-8 into the MIME encoded
-equivalent.  It uses L<utf8::is_utf8> for detection-8 and
+equivalent.  It uses C<utf8::is_utf8> for detection-8 and
 L<Email::MIME::RFC2047::Encoder> for convertion.  If L<utf8> is not
 installed, no conversion happens.  If L<Email::MIME::RFC2047::Encoder> is
-not installed, L<utf8::downgrade> is used instead.  In this last case, you will
+not installed, C<utf8::downgrade> is used instead.  In this last case, you will
 see a warning if you try to send UTF-8 headers.
 
 
@@ -651,8 +651,8 @@ streaming mode this filter will return either an HTTP::Request object or a
 block of content.  The HTTP::Request object's content will return empty. 
 The blocks of content will be parts of the request's body, up to
 Content-Length in size.  You distinguish between request objects and content
-blocks using C<Scalar::Util/bless> (See L</Streaming request> below).  This
-option supersedes L</MaxContent>.
+blocks using C<Scalar::Util/bless> (See L</Streaming Request> below).  This
+option supersedes C<MaxContent>.
 
 =head1 CAVEATS
 


### PR DESCRIPTION
Update Pod links to refer only to the utf8 module and not its methods,
fix a mis-capitalized internal reference, and convert the dangling
"MaxContent" link into a code reference.

Resolves bug: https://rt.cpan.org/Public/Bug/Display.html?id=124496