### PR TITLE
Add ListenQueue parameter to constructor

### DIFF
--- a/lib/POE/Component/Server/TCP.pm
+++ b/lib/POE/Component/Server/TCP.pm
@@ -58,6 +58,7 @@ sub new {
   my $port    = delete $param{Port};
   my $domain  = delete($param{Domain}) || AF_INET;
   my $concurrency = delete $param{Concurrency};
+  my $listen_queue = delete $param{ListenQueue};
 
   $port = 0 unless defined $port;
 
@@ -474,6 +475,7 @@ sub new {
           Reuse        => 'yes',
           SuccessEvent => 'tcp_server_got_connection',
           FailureEvent => 'tcp_server_got_error',
+          ListenQueue => $listen_queue,
         );
         $server_started and $server_started->(@_);
       },


### PR DESCRIPTION
Add ListenQueue parameter to constructor to be passed to POE::Wheel::SocketFactory constructor.

Resolved bug: https://rt.cpan.org/Ticket/Display.html?id=144766